### PR TITLE
Update documentation in Plugin_RES_0TSR_2.java

### DIFF
--- a/org/watto/ge/plugin/archive/Plugin_RES_0TSR_2.java
+++ b/org/watto/ge/plugin/archive/Plugin_RES_0TSR_2.java
@@ -120,7 +120,7 @@ public class Plugin_RES_0TSR_2 extends ArchivePlugin {
 
       // 4 - Length of RES file [+128]
       // 4 - Length of RES file [+128]
-      // 4 - null
+      // 4 - Unknown (Either 0, 128, or 1152)
       fm.skip(12);
 
       // 4 - Filename Directory Length


### PR DESCRIPTION
Bytes 45-48 of an Excitebots 0TSR file isn't always null. I've determined that they always represent the values 0, 128, or 1152. I don't quite know what these bytes actually represent yet though.